### PR TITLE
Add Search Function, Promote/Delete Function, & Update CSS

### DIFF
--- a/src/components/Admin/Admin.css
+++ b/src/components/Admin/Admin.css
@@ -1,12 +1,137 @@
-/* Container to make the table center */
+/* Admin container */
+.admin-container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f5f7fa 0%, #e4edf5 100%);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.admin-content {
+  padding: 20px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.admin-content h1 {
+  text-align: center;
+  margin: 20px 0 30px 0;
+  color: #2c5530;
+  font-size: 2.2em;
+}
+
+/* Tabs navigation */
+.admin-tabs {
+  display: flex;
+  gap: 10px;
+  margin: 20px 0;
+  padding-bottom: 10px;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.tab-btn {
+  padding: 12px 24px;
+  background: #f5f5f5;
+  border: none;
+  border-radius: 8px 8px 0 0;
+  cursor: pointer;
+  font-weight: 600;
+  color: #666;
+  transition: all 0.3s;
+}
+
+.tab-btn:hover {
+  background: #e9ecef;
+  color: #2E8B57;
+}
+
+.tab-btn.active {
+  background: #2E8B57;
+  color: white;
+  position: relative;
+}
+
+.tab-btn.active::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: #2E8B57;
+}
+
+/* Tab content */
+.tab-content {
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+
+
+/* Search container */
+.search-container {
+  display: flex;
+  gap: 10px;
+  margin: 20px 0 30px 0;
+  justify-content: center;
+  align-items: center;
+}
+
+.search-input {
+  width: 60%;
+  padding: 12px 20px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  font-size: 16px;
+  transition: border-color 0.3s;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #2E8B57;
+  box-shadow: 0 0 0 2px rgba(46, 139, 87, 0.2);
+}
+
+.clear-search-btn {
+  background: #6c757d;
+  color: white;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+  transition: background-color 0.3s;
+}
+
+.clear-search-btn:hover {
+  background: #5a6268;
+}
+
+/* Loading overlay */
+.loading-overlay {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 20px 30px;
+  border-radius: 10px;
+  z-index: 1000;
+}
+
+/* Table styles */
 ._table {
-  width: 90%;
+  width: 100%;
   margin: 20px auto;
   border-collapse: collapse;
   background: white;
   border-radius: 10px;
   overflow: hidden;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 15px rgba(0,0,0,0.1);
   font-family: Arial, sans-serif;
 }
 
@@ -41,10 +166,167 @@
   cursor: pointer;
 }
 
-/* Center the page title */
-h2 {
+/* Role badges */
+.role-badge {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: bold;
+  display: inline-block;
+}
+
+.admin-role {
+  background-color: #4a7c59;
+  color: white;
+}
+
+.user-role {
+  background-color: #6c757d;
+  color: white;
+}
+
+/* Status badges */
+.status-badge {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: bold;
+  display: inline-block;
+}
+
+.status-badge.active {
+  background-color: #28a745;
+  color: white;
+}
+
+.status-badge.pending {
+  background-color: #ffc107;
+  color: #212529;
+}
+
+.status-badge.rejected {
+  background-color: #dc3545;
+  color: white;
+}
+
+/* Pin action buttons */
+.approve-btn {
+  background-color: #28a745;
+  color: white;
+}
+
+.approve-btn:hover:not(:disabled) {
+  background-color: #218838;
+}
+
+.reject-btn {
+  background-color: #dc3545;
+  color: white;
+}
+
+.reject-btn:hover:not(:disabled) {
+  background-color: #c82333;
+}
+
+/* Action buttons */
+.action-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.action-btn {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.make-admin-btn {
+  background-color: #2E8B57;
+  color: white;
+}
+
+.make-admin-btn:hover:not(:disabled) {
+  background-color: #26734d;
+}
+
+.make-user-btn {
+  background-color: #6c757d;
+  color: white;
+}
+
+.make-user-btn:hover:not(:disabled) {
+  background-color: #5a6268;
+}
+
+.ban-btn {
+  background-color: #dc3545;
+  color: white;
+}
+
+.ban-btn:hover:not(:disabled) {
+  background-color: #c82333;
+}
+
+/* Admin note */
+.admin-note {
+  margin-top: 30px;
+  padding: 15px;
+  background: #fff8e1;
+  border-left: 4px solid #ffc107;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.admin-note code {
+  background: #f5f5f5;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: monospace;
+}
+
+/* Error message */
+.error-message {
+  color: #dc3545;
   text-align: center;
-  margin-top: 20px;
-  font-size: 28px;
-  color: #333;
+  padding: 40px;
+  font-size: 18px;
+}
+
+/* Responsive tables */
+@media (max-width: 768px) {
+  .admin-tabs {
+    flex-wrap: wrap;
+  }
+  
+  .tab-btn {
+    flex: 1;
+    min-width: 120px;
+    padding: 10px 15px;
+    font-size: 14px;
+  }
+  
+  ._table {
+    font-size: 12px;
+  }
+  
+  ._table th,
+  ._table td {
+    padding: 8px 10px;
+  }
+  
+  .action-buttons {
+    flex-direction: column;
+    gap: 5px;
+  }
 }

--- a/src/components/Admin/Admin.jsx
+++ b/src/components/Admin/Admin.jsx
@@ -2,26 +2,44 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import './Admin.css';
 
-function Admin({ user, handleLogout }) {
+function Admin({ user, setUser }) {
   const navigate = useNavigate();
   const BASE_URL = 'https://rv-n5oa.onrender.com';
 
-  const [users, setUsers] = useState(null);
+  // User states
+  const [users, setUsers] = useState([]);
+  const [filteredUsers, setFilteredUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  const[pins, setPins] = useState(null);
+  
+  // Pin states
+  const [pins, setPins] = useState([]);
+  const [pendingAddPins, setPendingAddPins] = useState([]);
+  const [pendingDelPins, setPendingDelPins] = useState([]);
   const [pinsLoading, setPinsLoading] = useState(true);
   const [pinsError, setPinsError] = useState(null);
   
-  const[add_pins, setAddPins] = useState(null);
-  const [add_pinsLoading, setAddPinsLoading] = useState(true);
-  const [add_pinsError, setAddPinsError] = useState(null);
+  // Search and loading states
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isLoadingAction, setIsLoadingAction] = useState(false);
+  const [activeTab, setActiveTab] = useState('users');
 
-  const[del_pins, setDelPins] = useState(null);
-  const [del_pinsLoading, setDelPinsLoading] = useState(true);
-  const [del_pinsError, setDelPinsError] = useState(null);
+  // Search functionality for users
+  useEffect(() => {
+    if (searchTerm.trim() === '') {
+      setFilteredUsers(users);
+    } else {
+      const filtered = users.filter(u => 
+        u.email?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        u.username?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        u.firstname?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        u.lastname?.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+      setFilteredUsers(filtered);
+    }
+  }, [searchTerm, users]);
 
+  // Fetch all users
   const fetchAllUsers = async () => {
     try {
       const response = await fetch(`${BASE_URL}/v1/user/users`, {
@@ -31,7 +49,7 @@ function Admin({ user, handleLogout }) {
 
       if (!response.ok) {
         if (response.status === 403) {
-          throw new Error('Access Denied.');
+          throw new Error('Access Denied. Admin privileges required.');
         }
         throw new Error(`Failed to fetch users: ${response.status}`);
       }
@@ -45,83 +63,288 @@ function Admin({ user, handleLogout }) {
     }
   };
 
+  // Fetch all pins data
   const fetchAllPins = async () => {
-    try{
-    const response = await fetch(`${BASE_URL}/v1/pin/admin/list`, {
-      method: 'GET',
-      credentials: 'include'
-    });
+    try {
+      const response = await fetch(`${BASE_URL}/v1/pin/admin/list`, {
+        method: 'GET',
+        credentials: 'include'
+      });
 
-    if (!response.ok) {
+      if (!response.ok) {
         if (response.status === 403) {
           throw new Error('Access Denied.');
         }
         throw new Error(`Failed to fetch pins: ${response.status}`);
       }
 
-    const data = await response.json();
+      const data = await response.json();
 
-    const pendingAdditions = data.add_pins;
-    const pendingDeletions = data.del_pins;
-    const allPins = data.pins;
+      return {
+        pendingAdditions: data.add_pins || [],
+        pendingDeletions: data.del_pins || [],
+        allPins: data.pins || []
+      };
 
-    return { pendingAdditions, pendingDeletions, allPins };
     } catch (error) {
       console.error('Fetch error:', error.message);
       throw error;
     }
   };
 
+  // User management functions
+  const handleMakeAdmin = async (userId) => {
+    if (!window.confirm('Are you sure you want to make this user an admin?')) {
+      return;
+    }
+
+    setIsLoadingAction(true);
+    try {
+      const response = await fetch(`${BASE_URL}/v1/user/change/role/${userId}/admin`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+
+      if (response.ok) {
+        alert('User role updated to admin successfully!');
+        loadUsers();
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to update user role');
+      }
+    } catch (error) {
+      console.error('Error making user admin:', error);
+      alert(`Error: ${error.message}`);
+    } finally {
+      setIsLoadingAction(false);
+    }
+  };
+
+  const handleMakeUser = async (userId) => {
+    if (!window.confirm('Are you sure you want to change this admin to regular user?')) {
+      return;
+    }
+
+    setIsLoadingAction(true);
+    try {
+      const response = await fetch(`${BASE_URL}/v1/user/change/role/${userId}/user`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+
+      if (response.ok) {
+        alert('User role updated to regular user successfully!');
+        loadUsers();
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to update user role');
+      }
+    } catch (error) {
+      console.error('Error making user admin:', error);
+      alert(`Error: ${error.message}`);
+    } finally {
+      setIsLoadingAction(false);
+    }
+  };
+
+  const handleBanUser = async (userId, email) => {
+    if (!window.confirm(`Are you sure you want to ban/delete user: ${email}? This action cannot be undone.`)) {
+      return;
+    }
+
+    setIsLoadingAction(true);
+    try {
+      // DELETE user endpoint - needs to be implemented
+      const response = await fetch(`${BASE_URL}/v1/user/delete/${userId}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+
+      if (response.ok) {
+        alert('User banned/deleted successfully!');
+        loadUsers();
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to ban user');
+      }
+    } catch (error) {
+      console.error('Error banning user:', error);
+      alert(`Error: ${error.message}`);
+    } finally {
+      setIsLoadingAction(false);
+    }
+  };
+
+  // Pin management functions - UPDATED WITH CORRECT ENDPOINTS
+  const handleApproveAddition = async (pinId) => {
+    if (!window.confirm('Approve and activate this pin?')) {
+      return;
+    }
+
+    setIsLoadingAction(true);
+    try {
+      const response = await fetch(`${BASE_URL}/v1/pin/center/action/${pinId}/a`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+
+      if (response.ok) {
+        alert('Pin approved and activated!');
+        loadPins();
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to approve pin');
+      }
+    } catch (error) {
+      console.error('Error approving pin:', error);
+      alert(`Error: ${error.message}`);
+    } finally {
+      setIsLoadingAction(false);
+    }
+  };
+
+  const handleRejectAddition = async (pinId) => {
+    if (!window.confirm('Reject this pin addition?')) {
+      return;
+    }
+
+    setIsLoadingAction(true);
+    try {
+      const response = await fetch(`${BASE_URL}/v1/pin/center/action/${pinId}/r`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+
+      if (response.ok) {
+        alert('Pin addition rejected!');
+        loadPins();
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to reject pin');
+      }
+    } catch (error) {
+      console.error('Error rejecting pin:', error);
+      alert(`Error: ${error.message}`);
+    } finally {
+      setIsLoadingAction(false);
+    }
+  };
+
+  const handleApproveDeletion = async (pinId) => {
+    if (!window.confirm('Approve this pin deletion? This will permanently delete the pin.')) {
+      return;
+    }
+
+    setIsLoadingAction(true);
+    try {
+      const response = await fetch(`${BASE_URL}/v1/pin/delete/${pinId}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+
+      if (response.ok) {
+        alert('Pin deleted successfully!');
+        loadPins();
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to delete pin');
+      }
+    } catch (error) {
+      console.error('Error approving deletion:', error);
+      alert(`Error: ${error.message}`);
+    } finally {
+      setIsLoadingAction(false);
+    }
+  };
+
+  const handleRejectDeletion = async (pinId) => {
+    if (!window.confirm('Reject this pin deletion request? The pin will remain active.')) {
+      return;
+    }
+
+    setIsLoadingAction(true);
+    try {
+      // Reject deletion by activating the pin again
+      const response = await fetch(`${BASE_URL}/v1/pin/center/action/${pinId}/a`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+
+      if (response.ok) {
+        alert('Pin deletion rejected - pin remains active!');
+        loadPins();
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'Failed to reject deletion');
+      }
+    } catch (error) {
+      console.error('Error rejecting deletion:', error);
+      alert(`Error: ${error.message}`);
+    } finally {
+      setIsLoadingAction(false);
+    }
+  };
+
+  // Load data functions
+  const loadUsers = async () => {
+    try {
+      const data = await fetchAllUsers();
+      setUsers(data.users || []);
+      setFilteredUsers(data.users || []);
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+      setUsers([]);
+      setFilteredUsers([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadPins = async () => {
+    try {
+      const data = await fetchAllPins();
+      setPins(data.allPins || []);
+      setPendingAddPins(data.pendingAdditions || []);
+      setPendingDelPins(data.pendingDeletions || []);
+      setPinsError(null);
+    } catch (err) {
+      setPinsError(err.message);
+      setPins([]);
+      setPendingAddPins([]);
+      setPendingDelPins([]);
+    } finally {
+      setPinsLoading(false);
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('user');
+    setUser(null);
+    navigate('/');
+  };
+
   useEffect(() => {
-    const loadUsers = async () => {
-      try {
-        const data = await fetchAllUsers();
-        setUsers(data.users);
-        setError(null);
-      } catch (err) {
-        setError(err.message);
-        setUsers(null);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    const loadPins = async () => {
-      try {
-        const data = await fetchAllPins();
-        setPins(data.allPins);
-        setPinsError(null);
-      } catch (err) {
-        setPinsError(err.message);
-        setPins(null);
-      } finally {
-        setPinsLoading(false);
-      }
-    };
-
-    loadPins();
-
     loadUsers();
-  }, [BASE_URL]);
+    loadPins();
+  }, []);
 
-  if (loading) {
-    return <p>Loading user list...</p>;
-  }
-
-  if (error) {
-    return <p>{error}</p>;
+  if (loading || pinsLoading) {
+    return (
+      <div className="admin-container">
+        <p>Loading admin data...</p>
+      </div>
+    );
   }
 
   return (
-    <div>
-
+    <div className="admin-container">
       <nav className="navbar">
-        <div className="nav-logo">BinFinder</div>
+        <div className="nav-logo">BinFinder Admin</div>
 
         <div className="menu-right">
           {user ? (
             <div className="user-menu">
-
               <button
                 className="nav-login-btn"
                 onClick={() => navigate('/')}
@@ -144,160 +367,336 @@ function Admin({ user, handleLogout }) {
         </div>
       </nav>
 
-      <div class="User_List">
-        <h2>User List</h2>
+      <div className="admin-content">
+        <h1>Admin Dashboard</h1>
+        
+        {/* Navigation Tabs */}
+        <div className="admin-tabs">
+          <button 
+            className={`tab-btn ${activeTab === 'users' ? 'active' : ''}`}
+            onClick={() => setActiveTab('users')}
+          >
+            User Management ({users.length})
+          </button>
+          <button 
+            className={`tab-btn ${activeTab === 'pins' ? 'active' : ''}`}
+            onClick={() => setActiveTab('pins')}
+          >
+            All Pins ({pins.length})
+          </button>
+          <button 
+            className={`tab-btn ${activeTab === 'pendingAdd' ? 'active' : ''}`}
+            onClick={() => setActiveTab('pendingAdd')}
+          >
+            Pending Additions ({pendingAddPins.length})
+          </button>
+          <button 
+            className={`tab-btn ${activeTab === 'pendingDel' ? 'active' : ''}`}
+            onClick={() => setActiveTab('pendingDel')}
+          >
+            Pending Deletions ({pendingDelPins.length})
+          </button>
+        </div>
 
-        <table class="_table">
-          <thead>
-            <tr>
-              <th>Email</th>
-              <th>Username</th>
-              <th>First Name</th>
-              <th>Last Name</th>
-              <th>Role</th>
-              <th>Point</th>
-            </tr>
-          </thead>
+        {isLoadingAction && (
+          <div className="loading-overlay">
+            Processing action...
+          </div>
+        )}
 
-          <tbody>
-            {users && users.length > 0 ? (
-              users.map((user, index) => (
-                <tr key={index}>
-                  <td>{user.email || 'N/A'}</td>
-                  <td>{user.username || 'N/A'}</td>
-                  <td>{user.firstname || 'N/A'}</td>
-                  <td>{user.lastname || 'N/A'}</td>
-                  <td>{user.role || 'N/A'}</td>
-                  <td>{user.point || 'N/A'}</td>
-                </tr>
-              ))
-            ) : (
-              <tr>
-                <td colSpan="6" style={{ textAlign: "center", fontStyle: "italic" }}>
-                  No users found or empty list.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+        {/* USER MANAGEMENT TAB */}
+        {activeTab === 'users' && (
+          <div className="tab-content">
+            {/* Search Bar */}
+            <div className="search-container">
+              <input
+                type="text"
+                placeholder="Search users by email, username, or name..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="search-input"
+              />
+              <button 
+                onClick={() => setSearchTerm('')}
+                className="clear-search-btn"
+              >
+                Clear
+              </button>
+            </div>
+
+            <div className="User_List">
+              <h2>User Management ({filteredUsers.length} users)</h2>
+
+              <table className="_table">
+                <thead>
+                  <tr>
+                    <th>Email</th>
+                    <th>Username</th>
+                    <th>First Name</th>
+                    <th>Last Name</th>
+                    <th>Role</th>
+                    <th>Points</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  {filteredUsers.length > 0 ? (
+                    filteredUsers.map((userItem, index) => (
+                      <tr key={index}>
+                        <td>{userItem.email || 'N/A'}</td>
+                        <td>{userItem.username || 'N/A'}</td>
+                        <td>{userItem.firstname || 'N/A'}</td>
+                        <td>{userItem.lastname || 'N/A'}</td>
+                        <td>
+                          <span className={`role-badge ${userItem.role === 'admin' ? 'admin-role' : 'user-role'}`}>
+                            {userItem.role || 'user'}
+                          </span>
+                        </td>
+                        <td>{userItem.point || '0'}</td>
+                        <td className="action-buttons">
+                          {userItem.role !== 'admin' ? (
+                            <button
+                              onClick={() => handleMakeAdmin(userItem.id || userItem._id)}
+                              className="action-btn make-admin-btn"
+                              disabled={isLoadingAction}
+                            >
+                              Make Admin
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() => handleMakeUser(userItem.id || userItem._id)}
+                              className="action-btn make-user-btn"
+                              disabled={isLoadingAction}
+                            >
+                              Make User
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleBanUser(userItem.id || userItem._id, userItem.email)}
+                            className="action-btn ban-btn"
+                            disabled={isLoadingAction}
+                          >
+                            Ban User
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan="7" style={{ textAlign: "center", fontStyle: "italic" }}>
+                        {searchTerm ? 'No users found matching your search.' : 'No users found.'}
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* ALL PINS TAB */}
+        {activeTab === 'pins' && (
+          <div className="tab-content">
+            <div className="Pins_List">
+              <h2>All Pins ({pins.length})</h2>
+
+              <table className="_table">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Location</th>
+                    <th>Information</th>
+                    <th>Address</th>
+                    <th>Type</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  {pins.length > 0 ? (
+                    pins.map((pin, index) => (
+                      <tr key={index}>
+                        <td className="pin-id">{pin.id?.substring(0, 8) || pin._id?.substring(0, 8) || 'N/A'}</td>
+                        <td>
+                          {pin.location
+                            ? `${pin.location.latitude?.toFixed(6)}, ${pin.location.longitude?.toFixed(6)}`
+                            : 'N/A'}
+                        </td>
+                        <td>{pin.infomation || pin.information || 'N/A'}</td>
+                        <td>{pin.adder || 'N/A'}</td>
+                        <td>
+                          <span className={`type-badge ${pin.type?.replace(/\s+/g, '-').toLowerCase()}`}>
+                            {pin.type || 'Unknown'}
+                          </span>
+                        </td>
+                        <td>
+                          <span className={`status-badge ${pin.status === 'active' ? 'active' : 'pending'}`}>
+                            {pin.status || 'pending'}
+                          </span>
+                        </td>
+                        <td className="action-buttons">
+                          <button
+                            onClick={() => handleApproveDeletion(pin.id || pin._id)}
+                            className="action-btn delete-btn"
+                            disabled={isLoadingAction}
+                          >
+                            Delete
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan="7" style={{ textAlign: "center", fontStyle: "italic" }}>
+                        No pins found.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* PENDING ADDITIONS TAB */}
+        {activeTab === 'pendingAdd' && (
+          <div className="tab-content">
+            <div className="Pend_Add_List">
+              <h2>Pending Pins For Addition ({pendingAddPins.length})</h2>
+
+              <table className="_table">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Location</th>
+                    <th>Information</th>
+                    <th>Address</th>
+                    <th>Type</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  {pendingAddPins.length > 0 ? (
+                    pendingAddPins.map((pin, index) => (
+                      <tr key={index}>
+                        <td className="pin-id">{pin.id?.substring(0, 8) || pin._id?.substring(0, 8) || 'N/A'}</td>
+                        <td>
+                          {pin.location
+                            ? `${pin.location.latitude?.toFixed(6)}, ${pin.location.longitude?.toFixed(6)}`
+                            : 'N/A'}
+                        </td>
+                        <td>{pin.infomation || pin.information || 'N/A'}</td>
+                        <td>{pin.adder || 'N/A'}</td>
+                        <td>
+                          <span className={`type-badge ${pin.type?.replace(/\s+/g, '-').toLowerCase()}`}>
+                            {pin.type || 'Unknown'}
+                          </span>
+                        </td>
+                        <td className="action-buttons">
+                          <button
+                            onClick={() => handleApproveAddition(pin.id || pin._id)}
+                            className="action-btn approve-btn"
+                            disabled={isLoadingAction}
+                          >
+                            Approve (a)
+                          </button>
+                          <button
+                            onClick={() => handleRejectAddition(pin.id || pin._id)}
+                            className="action-btn reject-btn"
+                            disabled={isLoadingAction}
+                          >
+                            Reject (r)
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan="6" style={{ textAlign: "center", fontStyle: "italic" }}>
+                        No pending pins to add.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* PENDING DELETIONS TAB */}
+        {activeTab === 'pendingDel' && (
+          <div className="tab-content">
+            <div className="Pend_Del_List">
+              <h2>Pending Pins For Deletion ({pendingDelPins.length})</h2>
+
+              <table className="_table">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Location</th>
+                    <th>Information</th>
+                    <th>Address</th>
+                    <th>Type</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  {pendingDelPins.length > 0 ? (
+                    pendingDelPins.map((pin, index) => (
+                      <tr key={index}>
+                        <td className="pin-id">{pin.id?.substring(0, 8) || pin._id?.substring(0, 8) || 'N/A'}</td>
+                        <td>
+                          {pin.location
+                            ? `${pin.location.latitude?.toFixed(6)}, ${pin.location.longitude?.toFixed(6)}`
+                            : 'N/A'}
+                        </td>
+                        <td>{pin.infomation || pin.information || 'N/A'}</td>
+                        <td>{pin.adder || 'N/A'}</td>
+                        <td>
+                          <span className={`type-badge ${pin.type?.replace(/\s+/g, '-').toLowerCase()}`}>
+                            {pin.type || 'Unknown'}
+                          </span>
+                        </td>
+                        <td className="action-buttons">
+                          <button
+                            onClick={() => handleApproveDeletion(pin.id || pin._id)}
+                            className="action-btn delete-btn"
+                            disabled={isLoadingAction}
+                          >
+                            Delete
+                          </button>
+                          <button
+                            onClick={() => handleRejectDeletion(pin.id || pin._id)}
+                            className="action-btn reject-btn"
+                            disabled={isLoadingAction}
+                          >
+                            Keep Active
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan="6" style={{ textAlign: "center", fontStyle: "italic" }}>
+                        No pending pins to delete.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* Endpoint Reference */}
+        <div className="admin-note">
+          <p><strong>Note:</strong> User deletion endpoint (<code>/v1/user/delete/:userId</code>) needs to be implemented.</p>
+        </div>
       </div>
-
-      <div class="Pins_List">
-        <h2>Pins List</h2>
-
-        <table class="_table">
-          <thead>
-            <tr>
-              <th>Location</th>
-              <th>Information</th>
-              <th>Address</th>
-              <th>Type</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            {pins && pins.length > 0 ? (
-              pins.map((pin, index) => (
-                <tr key={index}>
-                  <td>
-                    {pin.location
-                      ? `${pin.location.latitude}, ${pin.location.longitude}`
-                      : 'N/A'}
-                  </td>
-                  <td>{pin.infomation || pin.information || 'N/A'}</td>
-                  <td>{pin.adder || 'N/A'}</td>
-                  <td>{pin.type || 'N/A'}</td>
-                </tr>
-              ))
-            ) : (
-              <tr>
-                <td colSpan="4" style={{ textAlign: "center", fontStyle: "italic" }}>
-                  No pins found or empty list.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      <div class="Pend_Add_List">
-        <h2>Pending Pins For Addition</h2>
-
-        <table class="_table">
-          <thead>
-            <tr>
-              <th>Location</th>
-              <th>Information</th>
-              <th>Address</th>
-              <th>Type</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            {add_pins && add_pins.length > 0 ? (
-              add_pins.map((pin, index) => (
-                <tr key={index}>
-                  <td>
-                    {pin.location
-                      ? `${pin.location.latitude}, ${pin.location.longitude}`
-                      : 'N/A'}
-                  </td>
-                  <td>{pin.infomation || pin.information || 'N/A'}</td>
-                  <td>{pin.adder || 'N/A'}</td>
-                  <td>{pin.type || 'N/A'}</td>
-                </tr>
-              ))
-            ) : (
-              <tr>
-                {/* span across all table columns */}
-                <td colSpan="4" style={{ textAlign: "center", fontStyle: "italic" }}>
-                  No pending pins to add.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      <div class="Pend_Del_List">
-        <h2>Pending Pins For Deletion</h2>
-
-        <table class="_table">
-          <thead>
-            <tr>
-              <th>Location</th>
-              <th>Information</th>
-              <th>Address</th>
-              <th>Type</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            {del_pins && del_pins.length > 0 ? (
-              del_pins.map((pin, index) => (
-                <tr key={index}>
-                  <td>
-                    {pin.location
-                      ? `${pin.location.latitude}, ${pin.location.longitude}`
-                      : 'N/A'}
-                  </td>
-                  <td>{pin.infomation || pin.information || 'N/A'}</td>
-                  <td>{pin.adder || 'N/A'}</td>
-                  <td>{pin.type || 'N/A'}</td>
-                </tr>
-              ))
-            ) : (
-              <tr>
-                {/* span across all table columns */}
-                <td colSpan="4" style={{ textAlign: "center", fontStyle: "italic" }}>
-                  No pending pins to delete.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-
     </div>
   );
 }


### PR DESCRIPTION
Changes:

- Add search account function for admin page
- Add promote/delete account function in admin page
- Seperate tables into tabs
- Update CSS file

Note: Since the delete account paths are unavailable, I have made a note in the page. If anyone edits the admin page, you may remove it.

<img width="2559" height="1301" alt="Screenshot 2025-12-09 124218" src="https://github.com/user-attachments/assets/c3fdfa14-3764-457e-9819-67e7ac3a4f2d" />
<img width="2559" height="670" alt="Screenshot 2025-12-09 124234" src="https://github.com/user-attachments/assets/0e3b3125-4e85-4c4a-af68-b24a6a270428" />
<img width="2559" height="609" alt="Screenshot 2025-12-09 124251" src="https://github.com/user-attachments/assets/99684eca-2081-4715-8897-113eddbdb568" />
<img width="2555" height="632" alt="Screenshot 2025-12-09 124301" src="https://github.com/user-attachments/assets/313d7600-1e1d-47c4-b463-873d3fec23c6" />
